### PR TITLE
SES Domain Output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ aws-assumed-role/
 *.iml
 .direnv
 .envrc
+account-map/
 
 # Compiled and auto-generated files
 # Note that the leading "**/" appears necessary for Docker even if not for Git

--- a/src/README.md
+++ b/src/README.md
@@ -102,6 +102,7 @@ components:
 
 | Name | Description |
 |------|-------------|
+| <a name="output_domain"></a> [domain](#output\_domain) | The SES domain name |
 | <a name="output_smtp_password"></a> [smtp\_password](#output\_smtp\_password) | The SMTP password. This will be written to the state file in plain text. |
 | <a name="output_smtp_user"></a> [smtp\_user](#output\_smtp\_user) | Access key ID of the IAM user with permission to send emails from SES domain |
 | <a name="output_user_arn"></a> [user\_arn](#output\_user\_arn) | The ARN the IAM user with permission to send emails from SES domain |

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -24,3 +24,7 @@ output "user_arn" {
   description = "The ARN the IAM user with permission to send emails from SES domain"
 }
 
+output "domain" {
+  value       = local.ses_domain
+  description = "The SES domain name"
+}


### PR DESCRIPTION
## what
- Added SES domain as output, `domain`

## why
- Helpful as an output

## references
.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new output that exposes the SES domain name, enabling easier reference and integration in dependent configurations.
- Documentation
  - Updated the component README to document the new domain output in the Outputs table, clarifying its purpose and usage.
- Chores
  - Expanded the ignore list to exclude the account-map directory, keeping local files out of version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->