### PR TITLE
Add ses_user_enabled variable for SES email permissions

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -20,6 +20,8 @@ module "ses" {
   verify_dkim   = var.ses_verify_dkim
   verify_domain = var.ses_verify_domain
 
+  ses_user_enabled = var.ses_user_enabled
+
   context = module.this.context
 }
 
@@ -39,7 +41,7 @@ module "ssm_parameter_store" {
   source  = "cloudposse/ssm-parameter-store/aws"
   version = "0.13.0"
 
-  count = local.enabled ? 1 : 0
+  count = local.enabled && var.ses_user_enabled ? 1 : 0
 
   # KMS key is only applied to SecureString params
   # https://github.com/cloudposse/terraform-aws-ssm-parameter-store/blob/master/main.tf#L17

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -32,3 +32,9 @@ variable "ssm_prefix" {
   sensitive   = false
   description = "The prefix to use for the SSM parameters"
 }
+
+variable "ses_user_enabled" {
+  type        = bool
+  description = "Creates user with permission to send emails from SES domain"
+  default     = true
+}


### PR DESCRIPTION
## what
* Add the `ses_user_enabled` variable for SES email permissions

## why
* Organization policies often deny user creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration flag to control SES email user creation. You can now enable or disable automatic provisioning of a user with SES email sending permissions; the feature is enabled by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->