### PR TITLE
feat: make IAM user, group, KMS key, and SSM parameters conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Optionally, an IAM user and group can be created for SMTP authentication by sett
 
 **Stack Level**: Regional
 
+> [!IMPORTANT]
+> This release changes the default of `ses_user_enabled` from `true` to `false`.
+> Existing stacks that still need SMTP credentials must set `ses_user_enabled: true`
+> (and `ses_group_enabled: true` if they need the IAM group) before applying this version,
+> or Terraform will destroy the IAM/KMS/SSM resources created by earlier releases.
+
 Here's an example snippet for how to use this component with IAM roles (the default, recommended for ECS/Lambda workloads):
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -94,6 +94,22 @@ components:
           Service: ses
 ```
 
+If you want to provide the Route53 zone ID directly instead of looking it up via the `dns-delegated` remote state:
+
+```yaml
+components:
+  terraform:
+    ses:
+      vars:
+        enabled: true
+        name: ses
+        domain_template: "%[2]s.%[3]s.%[1]s.acme.org"
+        zone_id: "Z1234567890"
+        tags:
+          Team: sre
+          Service: ses
+```
+
 <!-- prettier-ignore-start -->
 <!-- prettier-ignore-end -->
 
@@ -176,6 +192,7 @@ components:
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | Route53 hosted zone ID. If provided, bypasses the `dns-delegated` remote state lookup. | `string` | `null` | no |
 
 ## Outputs
 
@@ -183,7 +200,7 @@ components:
 |------|-------------|
 | <a name="output_domain"></a> [domain](#output\_domain) | The SES domain name |
 | <a name="output_ses_domain_identity_arn"></a> [ses\_domain\_identity\_arn](#output\_ses\_domain\_identity\_arn) | The ARN of the SES domain identity |
-| <a name="output_smtp_password"></a> [smtp\_password](#output\_smtp\_password) | The SMTP password. Only available when `ses_user_enabled` is `true` |
+| <a name="output_smtp_password"></a> [smtp\_password](#output\_smtp\_password) | The SMTP password. Only available when `ses_user_enabled` is `true`. This value is stored in Terraform state, so protect the state backend with encryption and access controls. |
 | <a name="output_smtp_user"></a> [smtp\_user](#output\_smtp\_user) | Access key ID of the IAM user. Only available when `ses_user_enabled` is `true` |
 | <a name="output_user_arn"></a> [user\_arn](#output\_user\_arn) | The ARN of the IAM user. Only available when `ses_user_enabled` is `true` |
 | <a name="output_user_name"></a> [user\_name](#output\_user\_name) | Normalized name of the IAM user. Only available when `ses_user_enabled` is `true` |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@
 
 -->
 
-This component provisions Amazon Simple Email Service (SES) to act as an SMTP gateway. The credentials used for sending email can be retrieved from SSM.
+This component provisions Amazon Simple Email Service (SES) to act as an SMTP gateway.
+
+By default, the component sets up SES domain identity with DKIM and domain verification via Route53, suitable for use with IAM roles (e.g., ECS task roles).
+
+Optionally, an IAM user and group can be created for SMTP authentication by setting `ses_user_enabled` and `ses_group_enabled` to `true`. When enabled, credentials are stored in SSM Parameter Store and encrypted with a dedicated KMS key.
 
 
 > [!TIP]
@@ -52,7 +56,7 @@ This component provisions Amazon Simple Email Service (SES) to act as an SMTP ga
 
 **Stack Level**: Regional
 
-Here's an example snippet for how to use this component.
+Here's an example snippet for how to use this component with IAM roles (the default, recommended for ECS/Lambda workloads):
 
 ```yaml
 components:
@@ -64,9 +68,27 @@ components:
       vars:
         enabled: true
         name: ses
-        # {environment}.{stage}.{tenant}.acme.org
-        domain_template: "%s[2]s.%[3]s.%[1]s.acme.org"
-        # use this when `account-map` is deployed in a separate `tenant`
+        # format(domain_template, tenant, environment, stage)
+        # produces: dev.use1.platform.acme.org
+        domain_template: "%[2]s.%[3]s.%[1]s.acme.org"
+        tags:
+          Team: sre
+          Service: ses
+```
+
+To create an IAM user with SMTP credentials stored in SSM Parameter Store (for legacy or third-party integrations):
+
+```yaml
+components:
+  terraform:
+    ses:
+      vars:
+        enabled: true
+        name: ses
+        domain_template: "%[2]s.%[3]s.%[1]s.acme.org"
+        ses_user_enabled: true
+        ses_group_enabled: true
+        ssm_prefix: "/ses"
         tags:
           Team: sre
           Service: ses
@@ -146,7 +168,8 @@ components:
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
-| <a name="input_ses_user_enabled"></a> [ses\_user\_enabled](#input\_ses\_user\_enabled) | Creates user with permission to send emails from SES domain | `bool` | `true` | no |
+| <a name="input_ses_group_enabled"></a> [ses\_group\_enabled](#input\_ses\_group\_enabled) | Creates a group with permission to send emails from SES domain | `bool` | `false` | no |
+| <a name="input_ses_user_enabled"></a> [ses\_user\_enabled](#input\_ses\_user\_enabled) | Creates user with permission to send emails from SES domain | `bool` | `false` | no |
 | <a name="input_ses_verify_dkim"></a> [ses\_verify\_dkim](#input\_ses\_verify\_dkim) | If provided the module will create Route53 DNS records used for DKIM verification. | `bool` | `true` | no |
 | <a name="input_ses_verify_domain"></a> [ses\_verify\_domain](#input\_ses\_verify\_domain) | If provided the module will create Route53 DNS records used for domain verification. | `bool` | `true` | no |
 | <a name="input_ssm_prefix"></a> [ssm\_prefix](#input\_ssm\_prefix) | The prefix to use for the SSM parameters | `string` | `"/ses"` | no |
@@ -159,11 +182,12 @@ components:
 | Name | Description |
 |------|-------------|
 | <a name="output_domain"></a> [domain](#output\_domain) | The SES domain name |
-| <a name="output_smtp_password"></a> [smtp\_password](#output\_smtp\_password) | The SMTP password. This will be written to the state file in plain text. |
-| <a name="output_smtp_user"></a> [smtp\_user](#output\_smtp\_user) | Access key ID of the IAM user with permission to send emails from SES domain |
-| <a name="output_user_arn"></a> [user\_arn](#output\_user\_arn) | The ARN the IAM user with permission to send emails from SES domain |
-| <a name="output_user_name"></a> [user\_name](#output\_user\_name) | Normalized name of the IAM user with permission to send emails from SES domain |
-| <a name="output_user_unique_id"></a> [user\_unique\_id](#output\_user\_unique\_id) | The unique ID of the IAM user with permission to send emails from SES domain |
+| <a name="output_ses_domain_identity_arn"></a> [ses\_domain\_identity\_arn](#output\_ses\_domain\_identity\_arn) | The ARN of the SES domain identity |
+| <a name="output_smtp_password"></a> [smtp\_password](#output\_smtp\_password) | The SMTP password. Only available when `ses_user_enabled` is `true` |
+| <a name="output_smtp_user"></a> [smtp\_user](#output\_smtp\_user) | Access key ID of the IAM user. Only available when `ses_user_enabled` is `true` |
+| <a name="output_user_arn"></a> [user\_arn](#output\_user\_arn) | The ARN of the IAM user. Only available when `ses_user_enabled` is `true` |
+| <a name="output_user_name"></a> [user\_name](#output\_user\_name) | Normalized name of the IAM user. Only available when `ses_user_enabled` is `true` |
+| <a name="output_user_unique_id"></a> [user\_unique\_id](#output\_user\_unique\_id) | The unique ID of the IAM user. Only available when `ses_user_enabled` is `true` |
 <!-- markdownlint-restore -->
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -12,6 +12,12 @@ description: |-
 usage: |-
   **Stack Level**: Regional
 
+  > [!IMPORTANT]
+  > This release changes the default of `ses_user_enabled` from `true` to `false`.
+  > Existing stacks that still need SMTP credentials must set `ses_user_enabled: true`
+  > (and `ses_group_enabled: true` if they need the IAM group) before applying this version,
+  > or Terraform will destroy the IAM/KMS/SSM resources created by earlier releases.
+
   Here's an example snippet for how to use this component with IAM roles (the default, recommended for ECS/Lambda workloads):
 
   ```yaml

--- a/README.yaml
+++ b/README.yaml
@@ -3,12 +3,16 @@ name: "aws-ses"
 github_repo: "cloudposse-terraform-components/aws-ses"
 # Short description of this project
 description: |-
-  This component provisions Amazon Simple Email Service (SES) to act as an SMTP gateway. The credentials used for sending email can be retrieved from SSM.
+  This component provisions Amazon Simple Email Service (SES) to act as an SMTP gateway.
+
+  By default, the component sets up SES domain identity with DKIM and domain verification via Route53, suitable for use with IAM roles (e.g., ECS task roles).
+
+  Optionally, an IAM user and group can be created for SMTP authentication by setting `ses_user_enabled` and `ses_group_enabled` to `true`. When enabled, credentials are stored in SSM Parameter Store and encrypted with a dedicated KMS key.
 # Usage examples and guidance
 usage: |-
   **Stack Level**: Regional
 
-  Here's an example snippet for how to use this component.
+  Here's an example snippet for how to use this component with IAM roles (the default, recommended for ECS/Lambda workloads):
 
   ```yaml
   components:
@@ -20,9 +24,27 @@ usage: |-
         vars:
           enabled: true
           name: ses
-          # {environment}.{stage}.{tenant}.acme.org
-          domain_template: "%s[2]s.%[3]s.%[1]s.acme.org"
-          # use this when `account-map` is deployed in a separate `tenant`
+          # format(domain_template, tenant, environment, stage)
+          # produces: dev.use1.platform.acme.org
+          domain_template: "%[2]s.%[3]s.%[1]s.acme.org"
+          tags:
+            Team: sre
+            Service: ses
+  ```
+
+  To create an IAM user with SMTP credentials stored in SSM Parameter Store (for legacy or third-party integrations):
+
+  ```yaml
+  components:
+    terraform:
+      ses:
+        vars:
+          enabled: true
+          name: ses
+          domain_template: "%[2]s.%[3]s.%[1]s.acme.org"
+          ses_user_enabled: true
+          ses_group_enabled: true
+          ssm_prefix: "/ses"
           tags:
             Team: sre
             Service: ses

--- a/README.yaml
+++ b/README.yaml
@@ -50,6 +50,22 @@ usage: |-
             Service: ses
   ```
 
+  If you want to provide the Route53 zone ID directly instead of looking it up via the `dns-delegated` remote state:
+
+  ```yaml
+  components:
+    terraform:
+      ses:
+        vars:
+          enabled: true
+          name: ses
+          domain_template: "%[2]s.%[3]s.%[1]s.acme.org"
+          zone_id: "Z1234567890"
+          tags:
+            Team: sre
+            Service: ses
+  ```
+
   <!-- prettier-ignore-start -->
   <!-- prettier-ignore-end -->
 # External references

--- a/src/README.md
+++ b/src/README.md
@@ -16,6 +16,12 @@ Optionally, an IAM user and group can be created for SMTP authentication by sett
 
 **Stack Level**: Regional
 
+> [!IMPORTANT]
+> This release changes the default of `ses_user_enabled` from `true` to `false`.
+> Existing stacks that still need SMTP credentials must set `ses_user_enabled: true`
+> (and `ses_group_enabled: true` if they need the IAM group) before applying this version,
+> or Terraform will destroy the IAM/KMS/SSM resources created by earlier releases.
+
 Here's an example snippet for how to use this component with IAM roles (the default, recommended for ECS/Lambda workloads):
 
 ```yaml

--- a/src/README.md
+++ b/src/README.md
@@ -7,12 +7,16 @@ tags:
 
 # Component: `ses`
 
-This component provisions Amazon Simple Email Service (SES) to act as an SMTP gateway. The credentials used for sending email can be retrieved from SSM.
+This component provisions Amazon Simple Email Service (SES) to act as an SMTP gateway.
+
+By default, the component sets up SES domain identity with DKIM and domain verification via Route53, suitable for use with IAM roles (e.g., ECS task roles).
+
+Optionally, an IAM user and group can be created for SMTP authentication by setting `ses_user_enabled` and `ses_group_enabled` to `true`. When enabled, credentials are stored in SSM Parameter Store and encrypted with a dedicated KMS key.
 ## Usage
 
 **Stack Level**: Regional
 
-Here's an example snippet for how to use this component.
+Here's an example snippet for how to use this component with IAM roles (the default, recommended for ECS/Lambda workloads):
 
 ```yaml
 components:
@@ -24,9 +28,27 @@ components:
       vars:
         enabled: true
         name: ses
-        # {environment}.{stage}.{tenant}.acme.org
-        domain_template: "%s[2]s.%[3]s.%[1]s.acme.org"
-        # use this when `account-map` is deployed in a separate `tenant`
+        # format(domain_template, tenant, environment, stage)
+        # produces: dev.use1.platform.acme.org
+        domain_template: "%[2]s.%[3]s.%[1]s.acme.org"
+        tags:
+          Team: sre
+          Service: ses
+```
+
+To create an IAM user with SMTP credentials stored in SSM Parameter Store (for legacy or third-party integrations):
+
+```yaml
+components:
+  terraform:
+    ses:
+      vars:
+        enabled: true
+        name: ses
+        domain_template: "%[2]s.%[3]s.%[1]s.acme.org"
+        ses_user_enabled: true
+        ses_group_enabled: true
+        ssm_prefix: "/ses"
         tags:
           Team: sre
           Service: ses
@@ -94,7 +116,8 @@ components:
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
-| <a name="input_ses_user_enabled"></a> [ses\_user\_enabled](#input\_ses\_user\_enabled) | Creates user with permission to send emails from SES domain | `bool` | `true` | no |
+| <a name="input_ses_group_enabled"></a> [ses\_group\_enabled](#input\_ses\_group\_enabled) | Creates a group with permission to send emails from SES domain | `bool` | `false` | no |
+| <a name="input_ses_user_enabled"></a> [ses\_user\_enabled](#input\_ses\_user\_enabled) | Creates user with permission to send emails from SES domain | `bool` | `false` | no |
 | <a name="input_ses_verify_dkim"></a> [ses\_verify\_dkim](#input\_ses\_verify\_dkim) | If provided the module will create Route53 DNS records used for DKIM verification. | `bool` | `true` | no |
 | <a name="input_ses_verify_domain"></a> [ses\_verify\_domain](#input\_ses\_verify\_domain) | If provided the module will create Route53 DNS records used for domain verification. | `bool` | `true` | no |
 | <a name="input_ssm_prefix"></a> [ssm\_prefix](#input\_ssm\_prefix) | The prefix to use for the SSM parameters | `string` | `"/ses"` | no |
@@ -107,11 +130,12 @@ components:
 | Name | Description |
 |------|-------------|
 | <a name="output_domain"></a> [domain](#output\_domain) | The SES domain name |
-| <a name="output_smtp_password"></a> [smtp\_password](#output\_smtp\_password) | The SMTP password. This will be written to the state file in plain text. |
-| <a name="output_smtp_user"></a> [smtp\_user](#output\_smtp\_user) | Access key ID of the IAM user with permission to send emails from SES domain |
-| <a name="output_user_arn"></a> [user\_arn](#output\_user\_arn) | The ARN the IAM user with permission to send emails from SES domain |
-| <a name="output_user_name"></a> [user\_name](#output\_user\_name) | Normalized name of the IAM user with permission to send emails from SES domain |
-| <a name="output_user_unique_id"></a> [user\_unique\_id](#output\_user\_unique\_id) | The unique ID of the IAM user with permission to send emails from SES domain |
+| <a name="output_ses_domain_identity_arn"></a> [ses\_domain\_identity\_arn](#output\_ses\_domain\_identity\_arn) | The ARN of the SES domain identity |
+| <a name="output_smtp_password"></a> [smtp\_password](#output\_smtp\_password) | The SMTP password. Only available when `ses_user_enabled` is `true` |
+| <a name="output_smtp_user"></a> [smtp\_user](#output\_smtp\_user) | Access key ID of the IAM user. Only available when `ses_user_enabled` is `true` |
+| <a name="output_user_arn"></a> [user\_arn](#output\_user\_arn) | The ARN of the IAM user. Only available when `ses_user_enabled` is `true` |
+| <a name="output_user_name"></a> [user\_name](#output\_user\_name) | Normalized name of the IAM user. Only available when `ses_user_enabled` is `true` |
+| <a name="output_user_unique_id"></a> [user\_unique\_id](#output\_user\_unique\_id) | The unique ID of the IAM user. Only available when `ses_user_enabled` is `true` |
 <!-- markdownlint-restore -->
 
 

--- a/src/README.md
+++ b/src/README.md
@@ -54,6 +54,22 @@ components:
           Service: ses
 ```
 
+If you want to provide the Route53 zone ID directly instead of looking it up via the `dns-delegated` remote state:
+
+```yaml
+components:
+  terraform:
+    ses:
+      vars:
+        enabled: true
+        name: ses
+        domain_template: "%[2]s.%[3]s.%[1]s.acme.org"
+        zone_id: "Z1234567890"
+        tags:
+          Team: sre
+          Service: ses
+```
+
 <!-- prettier-ignore-start -->
 <!-- prettier-ignore-end -->
 
@@ -124,6 +140,7 @@ components:
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | Route53 hosted zone ID. If provided, bypasses the `dns-delegated` remote state lookup. | `string` | `null` | no |
 
 ## Outputs
 
@@ -131,7 +148,7 @@ components:
 |------|-------------|
 | <a name="output_domain"></a> [domain](#output\_domain) | The SES domain name |
 | <a name="output_ses_domain_identity_arn"></a> [ses\_domain\_identity\_arn](#output\_ses\_domain\_identity\_arn) | The ARN of the SES domain identity |
-| <a name="output_smtp_password"></a> [smtp\_password](#output\_smtp\_password) | The SMTP password. Only available when `ses_user_enabled` is `true` |
+| <a name="output_smtp_password"></a> [smtp\_password](#output\_smtp\_password) | The SMTP password. Only available when `ses_user_enabled` is `true`. This value is stored in Terraform state, so protect the state backend with encryption and access controls. |
 | <a name="output_smtp_user"></a> [smtp\_user](#output\_smtp\_user) | Access key ID of the IAM user. Only available when `ses_user_enabled` is `true` |
 | <a name="output_user_arn"></a> [user\_arn](#output\_user\_arn) | The ARN of the IAM user. Only available when `ses_user_enabled` is `true` |
 | <a name="output_user_name"></a> [user\_name](#output\_user\_name) | Normalized name of the IAM user. Only available when `ses_user_enabled` is `true` |

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,7 +1,7 @@
 locals {
   enabled     = module.this.enabled
   ses_domain  = format(var.domain_template, var.tenant, var.environment, var.stage)
-  ses_zone_id = module.dns_gbl_delegated.outputs.default_dns_zone_id
+  ses_zone_id = coalesce(var.zone_id, module.dns_gbl_delegated.outputs.default_dns_zone_id)
 
   aws_partition = data.aws_partition.current.partition
   account_id    = data.aws_caller_identity.current.account_id

--- a/src/main.tf
+++ b/src/main.tf
@@ -20,7 +20,8 @@ module "ses" {
   verify_dkim   = var.ses_verify_dkim
   verify_domain = var.ses_verify_domain
 
-  ses_user_enabled = var.ses_user_enabled
+  ses_user_enabled  = var.ses_user_enabled
+  ses_group_enabled = var.ses_group_enabled
 
   context = module.this.context
 }
@@ -28,6 +29,8 @@ module "ses" {
 module "kms_key_ses" {
   source  = "cloudposse/kms-key/aws"
   version = "0.12.2"
+
+  enabled = local.enabled && var.ses_user_enabled
 
   description             = "KMS key for SES"
   deletion_window_in_days = 10
@@ -84,7 +87,7 @@ module "ssm_parameter_store" {
 data "aws_iam_policy_document" "kms_key_ses" {
   #bridgecrew:skip=BC_AWS_IAM_57: Skipping `Write access allowed without constraint` check. This is a resource-based policy allowing the account to use the CMK.
   #bridgecrew:skip=BC_AWS_IAM_56: Skipping `Resource exposure allows modification of policies and exposes resources` check. See note above.
-  count = local.enabled ? 1 : 0
+  count = local.enabled && var.ses_user_enabled ? 1 : 0
 
   # https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-administrators
   # https://aws.amazon.com/premiumsupport/knowledge-center/update-key-policy-future/

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -11,7 +11,7 @@ output "domain" {
 output "smtp_password" {
   sensitive   = true
   value       = module.ses.ses_smtp_password
-  description = "The SMTP password. Only available when `ses_user_enabled` is `true`"
+  description = "The SMTP password. Only available when `ses_user_enabled` is `true`. This value is stored in Terraform state, so protect the state backend with encryption and access controls."
 }
 
 output "smtp_user" {

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,30 +1,35 @@
-output "smtp_password" {
-  sensitive   = true
-  value       = module.ses.ses_smtp_password
-  description = "The SMTP password. This will be written to the state file in plain text."
-}
-
-output "smtp_user" {
-  value       = module.ses.access_key_id
-  description = "Access key ID of the IAM user with permission to send emails from SES domain"
-}
-
-output "user_name" {
-  value       = module.ses.user_name
-  description = "Normalized name of the IAM user with permission to send emails from SES domain"
-}
-
-output "user_unique_id" {
-  value       = module.ses.user_unique_id
-  description = "The unique ID of the IAM user with permission to send emails from SES domain"
-}
-
-output "user_arn" {
-  value       = module.ses.user_arn
-  description = "The ARN the IAM user with permission to send emails from SES domain"
+output "ses_domain_identity_arn" {
+  value       = module.ses.ses_domain_identity_arn
+  description = "The ARN of the SES domain identity"
 }
 
 output "domain" {
   value       = local.ses_domain
   description = "The SES domain name"
+}
+
+output "smtp_password" {
+  sensitive   = true
+  value       = module.ses.ses_smtp_password
+  description = "The SMTP password. Only available when `ses_user_enabled` is `true`"
+}
+
+output "smtp_user" {
+  value       = module.ses.access_key_id
+  description = "Access key ID of the IAM user. Only available when `ses_user_enabled` is `true`"
+}
+
+output "user_name" {
+  value       = module.ses.user_name
+  description = "Normalized name of the IAM user. Only available when `ses_user_enabled` is `true`"
+}
+
+output "user_unique_id" {
+  value       = module.ses.user_unique_id
+  description = "The unique ID of the IAM user. Only available when `ses_user_enabled` is `true`"
+}
+
+output "user_arn" {
+  value       = module.ses.user_arn
+  description = "The ARN of the IAM user. Only available when `ses_user_enabled` is `true`"
 }

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -9,5 +9,12 @@ module "dns_gbl_delegated" {
   component   = "dns-delegated"
   environment = coalesce(var.dns_delegated_environment_name, local.dns_delegated_environment_name)
 
+  bypass        = !local.enabled || var.zone_id != null
+  ignore_errors = !local.enabled
+
+  defaults = {
+    default_dns_zone_id = ""
+  }
+
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -36,5 +36,11 @@ variable "ssm_prefix" {
 variable "ses_user_enabled" {
   type        = bool
   description = "Creates user with permission to send emails from SES domain"
-  default     = true
+  default     = false
+}
+
+variable "ses_group_enabled" {
+  type        = bool
+  description = "Creates a group with permission to send emails from SES domain"
+  default     = false
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -26,6 +26,12 @@ variable "dns_delegated_environment_name" {
   description = "`dns-delegated` component environment name"
 }
 
+variable "zone_id" {
+  type        = string
+  default     = null
+  description = "Route53 hosted zone ID. If provided, bypasses the `dns-delegated` remote state lookup."
+}
+
 variable "ssm_prefix" {
   type        = string
   default     = "/ses"

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -20,6 +20,27 @@ type ComponentSuite struct {
 	helper.TestSuite
 }
 
+func (s *ComponentSuite) waitForIdentityVerification(identityDomain string, awsRegion string) string {
+	client := awshelper.NewSESV2Client(s.T(), awsRegion)
+
+	var identityState string
+	var attempt int
+	for strings.ToLower(identityState) != "success" && attempt <= 60 {
+		identities, err := client.GetEmailIdentity(context.Background(), &sesv2.GetEmailIdentityInput{
+			EmailIdentity: &identityDomain,
+		})
+		if !assert.NoError(s.T(), err) {
+			break
+		}
+
+		identityState = string(identities.VerificationStatus)
+		time.Sleep(2 * time.Second)
+		attempt++
+	}
+	assert.Equal(s.T(), "SUCCESS", identityState)
+	return identityState
+}
+
 func (s *ComponentSuite) TestBasic() {
 	const component = "ses/basic"
 	const stack = "default-test"
@@ -51,24 +72,12 @@ func (s *ComponentSuite) TestBasic() {
 	userArn := atmos.Output(s.T(), options, "user_arn")
 	assert.NotEmpty(s.T(), userArn)
 
-	randomContentMessage := strings.ToLower(random.UniqueId())
 	identityDomain := fmt.Sprintf("%s-test.ue2.default.%s", hostnamePrefix, domain)
+	s.waitForIdentityVerification(identityDomain, awsRegion)
+
+	randomContentMessage := strings.ToLower(random.UniqueId())
 	senderEmail := fmt.Sprintf("test@%s", identityDomain)
 	client := awshelper.NewSESV2Client(s.T(), awsRegion)
-
-	var identityState string
-	var attempt int
-	for strings.ToLower(identityState) != "success" && attempt <= 60 {
-		identities, err := client.GetEmailIdentity(context.Background(), &sesv2.GetEmailIdentityInput{
-			EmailIdentity: &identityDomain,
-		})
-		assert.NoError(s.T(), err)
-
-		identityState = string(identities.VerificationStatus)
-		time.Sleep(2 * time.Second)
-		attempt++
-	}
-	assert.Equal(s.T(), "SUCCESS", identityState)
 
 	_, err := client.SendEmail(context.Background(), &sesv2.SendEmailInput{
 		Content: &types.EmailContent{
@@ -117,21 +126,7 @@ func (s *ComponentSuite) TestDefault() {
 	assert.Empty(s.T(), userArn)
 
 	identityDomain := fmt.Sprintf("%s-test.ue2.default.%s", hostnamePrefix, domain)
-	client := awshelper.NewSESV2Client(s.T(), awsRegion)
-
-	var identityState string
-	var attempt int
-	for strings.ToLower(identityState) != "success" && attempt <= 60 {
-		identities, err := client.GetEmailIdentity(context.Background(), &sesv2.GetEmailIdentityInput{
-			EmailIdentity: &identityDomain,
-		})
-		assert.NoError(s.T(), err)
-
-		identityState = string(identities.VerificationStatus)
-		time.Sleep(2 * time.Second)
-		attempt++
-	}
-	assert.Equal(s.T(), "SUCCESS", identityState)
+	s.waitForIdentityVerification(identityDomain, awsRegion)
 
 	s.DriftTest(component, stack, &inputs)
 }
@@ -154,7 +149,6 @@ func (s *ComponentSuite) TestEnabledFlag() {
 
 	s.VerifyEnabledFlag(component, stack, &inputs)
 }
-
 
 func TestRunSuite(t *testing.T) {
 	suite := new(ComponentSuite)

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -86,6 +86,56 @@ func (s *ComponentSuite) TestBasic() {
 	s.DriftTest(component, stack, &inputs)
 }
 
+func (s *ComponentSuite) TestDefault() {
+	const component = "ses/default"
+	const stack = "default-test"
+	const awsRegion = "us-east-2"
+
+	dnsDelegatedOptions := s.GetAtmosOptions("dns-delegated", stack, nil)
+	domain := atmos.Output(s.T(), dnsDelegatedOptions, "default_domain_name")
+	zoneId := atmos.Output(s.T(), dnsDelegatedOptions, "default_dns_zone_id")
+
+	hostnamePrefix := strings.ToLower(random.UniqueId())
+	inputs := map[string]interface{}{
+		"domain_template": hostnamePrefix + "-%[3]v.%[2]v.%[1]v." + domain,
+		"zone_id":         zoneId,
+	}
+	defer s.DestroyAtmosComponent(s.T(), component, stack, &inputs)
+	options, _ := s.DeployAtmosComponent(s.T(), component, stack, &inputs)
+	assert.NotNil(s.T(), options)
+
+	sesDomain := atmos.Output(s.T(), options, "domain")
+	assert.NotEmpty(s.T(), sesDomain)
+
+	sesDomainIdentityArn := atmos.Output(s.T(), options, "ses_domain_identity_arn")
+	assert.NotEmpty(s.T(), sesDomainIdentityArn)
+
+	smtpUser := atmos.Output(s.T(), options, "smtp_user")
+	assert.Empty(s.T(), smtpUser)
+
+	userArn := atmos.Output(s.T(), options, "user_arn")
+	assert.Empty(s.T(), userArn)
+
+	identityDomain := fmt.Sprintf("%s-test.ue2.default.%s", hostnamePrefix, domain)
+	client := awshelper.NewSESV2Client(s.T(), awsRegion)
+
+	var identityState string
+	var attempt int
+	for strings.ToLower(identityState) != "success" && attempt <= 60 {
+		identities, err := client.GetEmailIdentity(context.Background(), &sesv2.GetEmailIdentityInput{
+			EmailIdentity: &identityDomain,
+		})
+		assert.NoError(s.T(), err)
+
+		identityState = string(identities.VerificationStatus)
+		time.Sleep(2 * time.Second)
+		attempt++
+	}
+	assert.Equal(s.T(), "SUCCESS", identityState)
+
+	s.DriftTest(component, stack, &inputs)
+}
+
 func (s *ComponentSuite) TestEnabledFlag() {
 	const component = "ses/disabled"
 	const stack = "default-test"

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -27,11 +27,13 @@ func (s *ComponentSuite) TestBasic() {
 
 	dnsDelegatedOptions := s.GetAtmosOptions("dns-delegated", stack, nil)
 	domain := atmos.Output(s.T(), dnsDelegatedOptions, "default_domain_name")
+	zoneId := atmos.Output(s.T(), dnsDelegatedOptions, "default_dns_zone_id")
 
 	hostnamePrefix := strings.ToLower(random.UniqueId())
 	inputs := map[string]interface{}{
 		"domain_template": hostnamePrefix + "-%[3]v.%[2]v.%[1]v." + domain,
 		"ssm_prefix":      fmt.Sprintf("/ses/%s", hostnamePrefix),
+		"zone_id":         zoneId,
 	}
 	defer s.DestroyAtmosComponent(s.T(), component, stack, &inputs)
 	options, _ := s.DeployAtmosComponent(s.T(), component, stack, &inputs)
@@ -91,11 +93,13 @@ func (s *ComponentSuite) TestEnabledFlag() {
 
 	dnsDelegatedOptions := s.GetAtmosOptions("dns-delegated", stack, nil)
 	domain := atmos.Output(s.T(), dnsDelegatedOptions, "default_domain_name")
+	zoneId := atmos.Output(s.T(), dnsDelegatedOptions, "default_dns_zone_id")
 
 	hostnamePrefix := strings.ToLower(random.UniqueId())
 	inputs := map[string]interface{}{
 		"domain_template": hostnamePrefix + "-%[3]v.%[2]v.%[1]v." + domain,
 		"ssm_prefix":      fmt.Sprintf("/ses/%s", hostnamePrefix),
+		"zone_id":         zoneId,
 	}
 
 	s.VerifyEnabledFlag(component, stack, &inputs)

--- a/test/fixtures/stacks/catalog/usecase/basic.yaml
+++ b/test/fixtures/stacks/catalog/usecase/basic.yaml
@@ -8,10 +8,11 @@ components:
         name: ses
         ses_verify_domain: true
         ses_verify_dkim: true
+        ses_user_enabled: true
+        ses_group_enabled: true
         dns_delegated_environment_name: ue2
-        # {environment}.{stage}.{tenant}.acme.org
-        domain_template: "%s[2]s.%[3]s.%[1]s.acme.org"
-        # use this when `account-map` is deployed in a separate `tenant`
+        # format(domain_template, tenant, environment, stage)
+        domain_template: "%[2]s.%[3]s.%[1]s.acme.org"
         tags:
           Team: sre
           Service: ses

--- a/test/fixtures/stacks/catalog/usecase/default.yaml
+++ b/test/fixtures/stacks/catalog/usecase/default.yaml
@@ -1,0 +1,16 @@
+components:
+  terraform:
+    ses/default:
+      metadata:
+        component: target
+      vars:
+        enabled: true
+        name: ses
+        ses_verify_domain: true
+        ses_verify_dkim: true
+        dns_delegated_environment_name: ue2
+        # format(domain_template, tenant, environment, stage)
+        domain_template: "%[2]s.%[3]s.%[1]s.acme.org"
+        tags:
+          Team: sre
+          Service: ses

--- a/test/fixtures/stacks/catalog/usecase/disabled.yaml
+++ b/test/fixtures/stacks/catalog/usecase/disabled.yaml
@@ -9,9 +9,8 @@ components:
         ses_verify_domain: true
         ses_verify_dkim: true
         dns_delegated_environment_name: ue2
-        # {environment}.{stage}.{tenant}.acme.org
-        domain_template: "%s[2]s.%[3]s.%[1]s.acme.org"
-        # use this when `account-map` is deployed in a separate `tenant`
+        # format(domain_template, tenant, environment, stage)
+        domain_template: "%[2]s.%[3]s.%[1]s.acme.org"
         tags:
           Team: sre
           Service: ses

--- a/test/fixtures/stacks/orgs/default/test/tests.yaml
+++ b/test/fixtures/stacks/orgs/default/test/tests.yaml
@@ -3,4 +3,5 @@ import:
   - catalog/dns-primary
   - catalog/dns-delegated
   - catalog/usecase/basic
+  - catalog/usecase/default
   - catalog/usecase/disabled


### PR DESCRIPTION
## what

- Made IAM user, IAM group, KMS key, and SSM parameter resources conditional instead of always being created
- Changed `ses_user_enabled` default from `true` to `false` so the component provisions only the SES domain identity by default
- Added new `ses_group_enabled` variable (default `false`) to independently control IAM group creation
- Made `module.kms_key_ses` conditional on `ses_user_enabled` — the KMS key and its policy are only created when an IAM user is needed
- Made the `aws_iam_policy_document.kms_key_ses` data source conditional on `ses_user_enabled`
- Added new output `ses_domain_identity_arn` exposing the SES domain identity ARN
- Updated output descriptions to clarify they are only populated when `ses_user_enabled` is `true`
- Reordered outputs to surface `ses_domain_identity_arn` and `domain` as the primary outputs
- Updated documentation with two usage examples: IAM-role-based (default, recommended for ECS/Lambda) and IAM-user-based (for legacy/third-party SMTP integrations)
- Updated test fixtures to reflect the new variable defaults

## why

- Previously, the component always created an IAM user, IAM group, KMS key, and SSM parameters even when they were not needed
- Most modern workloads (ECS tasks, Lambda functions) use IAM roles for SES access and do not need dedicated SMTP credentials
- Creating unnecessary IAM users and access keys increases the security surface area without providing value
- Making these resources opt-in follows the principle of least privilege and reduces infrastructure footprint for the common case
- The KMS key and SSM parameters are only meaningful when SMTP credentials exist, so they should be gated on the same condition

## references

- **BREAKING CHANGE**: Existing deployments that rely on the IAM user being created by default must explicitly set `ses_user_enabled: true` (and `ses_group_enabled: true` if the group is needed) to preserve current behavior
- [AWS SES SMTP credentials documentation](https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html)
- [AWS SES sending authorization with IAM](https://docs.aws.amazon.com/ses/latest/dg/sending-authorization.html)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded SES docs: default DKIM/domain verification, IAM-role recommendation, domain_template formatting guidance, examples for IAM-user SMTP credentials stored in SSM (KMS-encrypted), and a caution about enabling SMTP to avoid resource deletion.

* **New Features**
  * Optional SES sending group flag and explicit Route53 zone_id override.
  * New output: ses_domain_identity_arn.

* **Changes**
  * SMTP user provisioning now disabled by default (ses_user_enabled=false); SMTP-related outputs are conditional and note state/backend security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->